### PR TITLE
add scala 2.13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ was created and make it available while executing the future's body.
             Future("Hello Kamon!")
               // The active span is expected to be available during all intermediate processing.
               .map(_.length)
-              .flatMap(len ⇒ Future(len.toString))
-              .map(_ ⇒ Kamon.currentContext().get(StringKey))
+              .flatMap(len => Future(len.toString))
+              .map(_ => Kamon.currentContext().get(StringKey))
           }
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,8 @@ val catsEffect       = "org.typelevel" %%  "cats-effect"                % "1.2.0
 resolvers in ThisBuild += Resolver.bintrayRepo("kamon-io", "snapshots")
 resolvers in ThisBuild += Resolver.mavenLocal
 
+def crossCompile = crossScalaVersions += "2.13.0" // until https://github.com/kamon-io/kamon-sbt-umbrella/pull/3
+
 lazy val `kamon-futures` = (project in file("."))
   .enablePlugins(JavaAgent)
   .settings(noPublishing: _*)
@@ -60,6 +62,8 @@ lazy val `kamon-scalaz-future` = (project in file("kamon-scalaz-future"))
 lazy val `kamon-scala-future` = (project in file("kamon-scala-future"))
   .enablePlugins(JavaAgent)
   .settings(instrumentationSettings)
+  .settings(crossCompile)
+  .settings(scalaVersion := "2.13.0")
   .settings(
     bintrayPackage := "kamon-futures",
     libraryDependencies ++=

--- a/kamon-scala-future/src/main/scala-2.13/kamon/instrumentation/futures/scala/FutureChainingInstrumentation.scala
+++ b/kamon-scala-future/src/main/scala-2.13/kamon/instrumentation/futures/scala/FutureChainingInstrumentation.scala
@@ -1,0 +1,139 @@
+package kamon.instrumentation.futures.scala
+
+import kamon.Kamon
+import kamon.context.Context
+import kamon.context.Storage.Scope
+import kamon.instrumentation.context._
+import kamon.instrumentation.futures.scala.CallbackRunnableRunInstrumentation.InternalState
+import kanela.agent.api.instrumentation.InstrumentationBuilder
+import kanela.agent.api.instrumentation.bridge.Bridge
+import kanela.agent.libs.net.bytebuddy.asm.Advice
+
+import scala.concurrent.Future
+
+/**
+  * Ensures that chained transformations on Scala Futures (e.g. future.map(...).flatmap(...)) will propagate the context
+  * set on each transformation to the next transformation.
+  */
+class FutureChainingInstrumentation extends InstrumentationBuilder {
+
+  /**
+    * Captures the current context when a Try instance is created. Since Future's use a Try underneath to handle the
+    * completed value we decided to instrument that instead. As a side effect, all Try instances are instrumented even
+    * if they are not being used in a future, although that is just one extra field that will not be used or visible to
+    * anybody who is not looking for it.
+    */
+  onSubTypesOf("scala.util.Try")
+    .mixin(classOf[HasContext.Mixin])
+    .advise(isConstructor, CaptureCurrentContextOnExit)
+
+  /**
+    * Ensures that if resolveTry returns a new Try instance, the captured context will be transferred to that the new
+    * instance.
+    */
+  onType("scala.concurrent.impl.Promise")
+    .advise(method("resolveTry"), CopyContextFromArgumentToResult)
+
+  /**
+    * Captures the scheduling timestamp when a CallbackRunnable is scheduled for execution and then uses the Context
+    * from the completed value as the current Context while the Runnable is executed.
+    */
+  onType("scala.concurrent.impl.CallbackRunnable")
+    .mixin(classOf[HasContext.Mixin])
+    .mixin(classOf[HasTimestamp.Mixin])
+    .bridge(classOf[InternalState])
+    .advise(isConstructor, CaptureCurrentContextOnExit)
+    .advise(method("run"), CallbackRunnableRunInstrumentation)
+    .advise(method("executeWithValue"), CaptureCurrentTimestampOnEnter)
+
+  /**
+    * In Scala 2.12, all Futures are created by calling .map(...) on Future.unit and if happens that while that seed
+    * Future was initialized there was non-empty current Context, that Context will be tied to all Futures which is
+    * obviously wrong. Little tweak ensures that no Context is retained on that seed Future.
+    */
+  onType("scala.concurrent.Future$")
+    .advise(isConstructor, CleanContextFromSeedFuture)
+
+}
+
+object CallbackRunnableRunInstrumentation {
+
+  /**
+    * Exposes access to the "value" member of "scala.concurrent.impl.CallbackRunnable".
+    */
+  trait InternalState {
+
+    @Bridge("scala.util.Try value()")
+    def valueBridge(): Any
+
+  }
+
+  @Advice.OnMethodEnter(suppress = classOf[Throwable])
+  def enter(@Advice.This runnable: HasContext with HasTimestamp with InternalState): Scope = {
+    val timestamp = runnable.timestamp
+    val valueContext = runnable.valueBridge().asInstanceOf[HasContext].context
+    val context = if(valueContext.nonEmpty()) valueContext else runnable.context
+
+    storeCurrentRunnableTimestamp(timestamp)
+    Kamon.store(context)
+  }
+
+  @Advice.OnMethodExit(suppress = classOf[Throwable])
+  def exit(@Advice.Enter scope: Scope): Unit = {
+    clearCurrentRunnableTimestamp()
+    scope.close()
+  }
+
+  /**
+    * Exposes the scheduling timestamp of the currently running CallbackRunnable, if any. This timestamp should be
+    * taken when the CallbackRunnable.executeWithValue method is called.
+    */
+  def currentRunnableScheduleTimestamp(): Option[Long] =
+    Option(_schedulingTimestamp.get())
+
+  /** Keeps track of the scheduling time of the CallbackRunnable currently running on this thread, if any */
+  private val _schedulingTimestamp = new ThreadLocal[java.lang.Long]()
+
+  private def storeCurrentRunnableTimestamp(timestamp: Long): Unit =
+    _schedulingTimestamp.set(timestamp)
+
+  private def clearCurrentRunnableTimestamp(): Unit =
+    _schedulingTimestamp.remove()
+}
+
+object CopyContextFromArgumentToResult {
+
+  @Advice.OnMethodExit(suppress = classOf[Throwable])
+  def exit(@Advice.Argument(0) arg: Any, @Advice.Return result: Any): Unit = {
+    result.asInstanceOf[HasContext].setContext(arg.asInstanceOf[HasContext].context)
+  }
+}
+
+object CopyCurrentContextToArgument {
+
+  @Advice.OnMethodEnter(suppress = classOf[Throwable])
+  def enter(@Advice.Argument(0) arg: Any): Unit =
+    arg.asInstanceOf[HasContext].setContext(Kamon.currentContext())
+}
+
+object CleanContextFromSeedFuture {
+
+  @Advice.OnMethodExit
+  def exit(@Advice.This futureCompanionObject: Any): Unit = {
+    val unitField = futureCompanionObject.getClass.getDeclaredField("unit")
+    unitField.setAccessible(true)
+
+    // FutureInstrumentationSpec fails here.
+    // javap shows that Future.unit became static from 2.12 => 2.13
+    // scala 2.12: private final scala.concurrent.Future<scala.runtime.BoxedUnit> unit;
+    // scala 2.13: private static final scala.concurrent.Future<scala.runtime.BoxedUnit> unit;
+
+    // But getting the value of the field returns null. It doesn't appear to be initialized at this point.
+    println(unitField.get(null)) // returns null
+
+    // This logic throws on Future.value since the Future is null here.
+//    unitField.get(futureCompanionObject).asInstanceOf[Future[Unit]].value.foreach(unitValue => {
+//      unitValue.asInstanceOf[HasContext].setContext(Context.Empty)
+//    })
+  }
+}

--- a/kamon-scala-future/src/test/scala/kamon/instrumentation/futures/scala/FutureInstrumentationSpec.scala
+++ b/kamon-scala-future/src/test/scala/kamon/instrumentation/futures/scala/FutureInstrumentationSpec.scala
@@ -121,7 +121,7 @@ class FutureInstrumentationSpec extends WordSpec with ScalaFutures with Matchers
           Future(Kamon.currentContext().getTag(plain("key")))
         }
 
-        whenReady(contextTag)(tagValue ⇒ tagValue shouldBe "value")
+        whenReady(contextTag)(tagValue => tagValue shouldBe "value")
         ensureExecutionContextIsClean()
       }
 
@@ -131,11 +131,11 @@ class FutureInstrumentationSpec extends WordSpec with ScalaFutures with Matchers
             Future("Hello Kamon!")
               // The current context is expected to be available during all intermediate processing.
               .map(_.length)
-              .flatMap(len ⇒ Future(len.toString))
-              .map(_ ⇒ Kamon.currentContext().getTag(plain("key")))
+              .flatMap(len => Future(len.toString))
+              .map(_ => Kamon.currentContext().getTag(plain("key")))
           }
 
-        whenReady(tagAfterTransformation)(tagValue ⇒ tagValue shouldBe "value")
+        whenReady(tagAfterTransformation)(tagValue => tagValue shouldBe "value")
         ensureExecutionContextIsClean()
       }
     }

--- a/kamon-scalaz-future/src/test/scala/kamon/instrumentation/futures/scalaz/FutureInstrumentationSpec.scala
+++ b/kamon-scalaz-future/src/test/scala/kamon/instrumentation/futures/scalaz/FutureInstrumentationSpec.scala
@@ -52,8 +52,8 @@ class FutureInstrumentationSpec extends WordSpec with Matchers with ScalaFutures
           Future("Hello Kamon!")
             // The current context is expected to be available during all intermediate processing.
             .map(_.length)
-            .flatMap(len ⇒ Future(len.toString))
-            .map(_ ⇒ Kamon.currentContext().getTag(plain("key")))
+            .flatMap(len => Future(len.toString))
+            .map(_ => Kamon.currentContext().getTag(plain("key")))
             .unsafeStart
         }
 

--- a/kamon-twitter-future/src/test/scala/kamon/instrumentation/futures/twitter/FutureInstrumentationSpec.scala
+++ b/kamon-twitter-future/src/test/scala/kamon/instrumentation/futures/twitter/FutureInstrumentationSpec.scala
@@ -52,8 +52,8 @@ class FutureInstrumentationSpec extends WordSpec with Matchers with ScalaFutures
           FuturePool.unboundedPool("Hello Kamon!")
             // The current context is expected to be available during all intermediate processing.
             .map(_.length)
-            .flatMap(len ⇒ FuturePool.unboundedPool(len.toString))
-            .map(_ ⇒ Kamon.currentContext().getTag(plain("key")))
+            .flatMap(len => FuturePool.unboundedPool(len.toString))
+            .map(_ => Kamon.currentContext().getTag(plain("key")))
         }
 
         Await.result(tagAfterTransformations) shouldBe "value"


### PR DESCRIPTION
I need some help with this. Copied over `scala_2.12/.../FutureChainingInstrumentation` to `scala_2.13`, but `FutureInstrumentationSpec` fails.

```
javap -p 2.1*/scala/concurrent/Future\$.class | grep unit
  private final scala.concurrent.Future<scala.runtime.BoxedUnit> unit; // 2.12
  private static final scala.concurrent.Future<scala.runtime.BoxedUnit> unit; // 2.13
```

The `Future.unit` field went static in 2.13. What's the best way to handle this?