### PR TITLE
Scala 2.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script:
 scala:
    - 2.12.6
 jdk:
-   - oraclejdk8
+   - openjdk8
 before_script:
   - mkdir $TRAVIS_BUILD_DIR/tmp
   - export SBT_OPTS="-Djava.io.tmpdir=$TRAVIS_BUILD_DIR/tmp"

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ was created and make it available while executing the future's body.
             Future("Hello Kamon!")
               // The active span is expected to be available during all intermediate processing.
               .map(_.length)
-              .flatMap(len ⇒ Future(len.toString))
-              .map(_ ⇒ Kamon.currentContext().get(StringKey))
+              .flatMap(len => Future(len.toString))
+              .map(_ => Kamon.currentContext().get(StringKey))
           }
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,16 +15,17 @@
 
 val kamonCore        = "io.kamon"     %% "kamon-core"                   % "2.0.0-RC1"
 val kamonTestkit     = "io.kamon"     %% "kamon-testkit"                % "2.0.0-RC1"
-val kamonExecutors   = "io.kamon"     %% "kamon-executors"              % "2.0.0-RC1"
+val kamonExecutors   = "io.kamon"     %% "kamon-executors"              % "2.0.0-RC2"
 val kamonInstrument  = "io.kamon"     %% "kamon-instrumentation-common" % "2.0.0-RC1"
-val kanelaAgent      = "io.kamon"     %  "kanela-agent"                 % "1.0.0-M3"
+val kanelaAgent      = "io.kamon"     %  "kanela-agent"                 % "1.0.0-RC4"
 
 val twitterUtilCore  = "com.twitter"   %% "util-core"                   % "6.40.0"
-val scalazConcurrent = "org.scalaz"    %% "scalaz-concurrent"           % "7.2.8"
+val scalazConcurrent = "org.scalaz"    %% "scalaz-concurrent"           % "7.2.28"
 val catsEffect       = "org.typelevel" %%  "cats-effect"                % "1.2.0"
 
 resolvers in ThisBuild += Resolver.bintrayRepo("kamon-io", "snapshots")
 resolvers in ThisBuild += Resolver.mavenLocal
+scalaVersion := "2.13.0"
 
 lazy val `kamon-futures` = (project in file("."))
   .enablePlugins(JavaAgent)
@@ -52,6 +53,7 @@ lazy val `kamon-scalaz-future` = (project in file("kamon-scalaz-future"))
   .settings(instrumentationSettings)
   .settings(
     bintrayPackage := "kamon-futures",
+    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
     libraryDependencies ++=
       compileScope(kamonCore) ++
       providedScope(scalazConcurrent, kamonExecutors) ++
@@ -61,6 +63,7 @@ lazy val `kamon-scala-future` = (project in file("kamon-scala-future"))
   .enablePlugins(JavaAgent)
   .settings(instrumentationSettings)
   .settings(
+    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
     bintrayPackage := "kamon-futures",
     libraryDependencies ++=
       compileScope(kamonCore, kamonInstrument) ++

--- a/kamon-scala-future/src/main/scala-2.13/kamon/instrumentation/futures/scala/FutureChainingInstrumentation.scala
+++ b/kamon-scala-future/src/main/scala-2.13/kamon/instrumentation/futures/scala/FutureChainingInstrumentation.scala
@@ -1,0 +1,141 @@
+package kamon.instrumentation.futures.scala
+
+import kamon.Kamon
+import kamon.context.Context
+import kamon.context.Storage.Scope
+import kamon.instrumentation.context._
+import kamon.instrumentation.futures.scala.CallbackRunnableRunInstrumentation.InternalState
+import kanela.agent.api.instrumentation.InstrumentationBuilder
+import kanela.agent.api.instrumentation.bridge.FieldBridge
+import kanela.agent.libs.net.bytebuddy.asm.Advice
+import kanela.agent.libs.net.bytebuddy.matcher.ElementMatchers.isTypeInitializer
+
+import scala.concurrent.Future
+import scala.util.Try
+
+/**
+  * Ensures that chained transformations on Scala Futures (e.g. future.map(...).flatmap(...)) will propagate the context
+  * set on each transformation to the next transformation.
+  */
+class FutureChainingInstrumentation extends InstrumentationBuilder {
+
+  /**
+    * Captures the current context when a Try instance is created. Since Future's use a Try underneath to handle the
+    * completed value we decided to instrument that instead. As a side effect, all Try instances are instrumented even
+    * if they are not being used in a future, although that is just one extra field that will not be used or visible to
+    * anybody who is not looking for it.
+    */
+  onSubTypesOf("scala.util.Try")
+    .mixin(classOf[HasContext.Mixin])
+    .advise(isConstructor, CaptureCurrentContextOnExit)
+
+  /**
+    * Ensures that if Promise.resolve returns a new Try instance, the captured context will be transferred to that new
+    * instance.
+    */
+  onType("scala.concurrent.impl.Promise")
+    .advise(method("resolve"), CopyContextFromArgumentToResult)
+
+  /**
+    * Captures the scheduling timestamp when a CallbackRunnable is scheduled for execution and then uses the Context
+    * from the completed value as the current Context while the Runnable is executed.
+    */
+  onType("scala.concurrent.impl.Promise$Transformation")
+    .mixin(classOf[HasContext.Mixin])
+    .mixin(classOf[HasTimestamp.Mixin])
+    .bridge(classOf[InternalState])
+    .advise(isConstructor, CaptureCurrentContextOnExit)
+    .advise(method("run"), CallbackRunnableRunInstrumentation)
+    .advise(method("submitWithValue"), CaptureCurrentTimestampOnEnter)
+
+  /**
+    * In Scala 2.13, all Futures are created by calling .map(...) on Future.unit and if happens that while that seed
+    * Future was initialized there was non-empty current Context, that Context will be tied to all Futures which is
+    * obviously wrong. Little tweak ensures that no Context is retained on that seed Future.
+    */
+  onType("scala.concurrent.Future$")
+    .advise(isTypeInitializer, classOf[CleanContextFromSeedFuture])
+
+}
+
+object CallbackRunnableRunInstrumentation {
+
+  /**
+    * Exposes access to the value to be used for a Transformation.
+    */
+  trait InternalState {
+
+    @FieldBridge("_arg")
+    def valueBridge(): Try[_]
+
+  }
+
+  @Advice.OnMethodEnter(suppress = classOf[Throwable])
+  def enter(@Advice.This runnable: HasContext with HasTimestamp with InternalState): Scope = {
+    val timestamp = runnable.timestamp
+    val valueContext = runnable.valueBridge().asInstanceOf[HasContext].context
+    val context = if(valueContext.nonEmpty()) valueContext else runnable.context
+
+    storeCurrentRunnableTimestamp(timestamp)
+    Kamon.store(context)
+  }
+
+  @Advice.OnMethodExit(suppress = classOf[Throwable])
+  def exit(@Advice.Enter scope: Scope): Unit = {
+    clearCurrentRunnableTimestamp()
+    scope.close()
+  }
+
+  /**
+    * Exposes the scheduling timestamp of the currently running Transformation, if any. This timestamp should be
+    * taken when the Transformation.submitWithValue method is called.
+    */
+  def currentRunnableScheduleTimestamp(): Option[Long] =
+    Option(_schedulingTimestamp.get())
+
+  /** Keeps track of the scheduling time of the Transformation currently running on this thread, if any */
+  private val _schedulingTimestamp = new ThreadLocal[java.lang.Long]()
+
+  private def storeCurrentRunnableTimestamp(timestamp: Long): Unit =
+    _schedulingTimestamp.set(timestamp)
+
+  private def clearCurrentRunnableTimestamp(): Unit =
+    _schedulingTimestamp.remove()
+}
+
+object CopyContextFromArgumentToResult {
+
+  @Advice.OnMethodExit(suppress = classOf[Throwable])
+  def exit(@Advice.Argument(0) arg: Any, @Advice.Return result: Any): Unit = {
+    result.asInstanceOf[HasContext].setContext(arg.asInstanceOf[HasContext].context)
+  }
+}
+
+object CopyCurrentContextToArgument {
+
+  @Advice.OnMethodEnter(suppress = classOf[Throwable])
+  def enter(@Advice.Argument(0) arg: Any): Unit =
+    arg.asInstanceOf[HasContext].setContext(Kamon.currentContext())
+}
+
+class CleanContextFromSeedFuture
+object CleanContextFromSeedFuture {
+
+  @Advice.OnMethodExit
+  def exit(): Unit = {
+    try {
+      val futureCompanionObject = Class.forName("scala.concurrent.Future$", false, getClass.getClassLoader)
+      val unitField = futureCompanionObject.getDeclaredField("unit")
+
+      unitField.setAccessible(true)
+      unitField.get(futureCompanionObject)
+        .asInstanceOf[Future[Unit]]
+        .value
+        .foreach(unitValue => unitValue.asInstanceOf[HasContext].setContext(Context.Empty))
+
+    } catch {
+      case t: Throwable => t.printStackTrace() // Is there anything better to do here?
+    }
+
+  }
+}

--- a/kamon-scala-future/src/main/scala/kamon/instrumentation/futures/scala/ScalaFutureInstrumentation.scala
+++ b/kamon-scala-future/src/main/scala/kamon/instrumentation/futures/scala/ScalaFutureInstrumentation.scala
@@ -45,7 +45,7 @@ object ScalaFutureInstrumentation {
     *            bytecode instrumentation. If instrumentation is disabled you risk leaving dirty threads that can cause
     *            incorrect Context propagation behavior.
     */
-  def traced[S](operationName: String)(body: => S)(implicit settings: Settings): S = {
+  def trace[S](operationName: String)(body: => S)(implicit settings: Settings): S = {
     val span = startedSpan(operationName, settings)
     Kamon.store(Kamon.currentContext().withKey(Span.Key, span))
 
@@ -78,7 +78,7 @@ object ScalaFutureInstrumentation {
     *            bytecode instrumentation. If instrumentation is disabled you risk leaving dirty threads that can cause
     *            incorrect Context propagation behavior.
     */
-  def tracedCallback[T, S](operationName: String)(body: T => S)(implicit settings: Settings): T => S = { t: T =>
+  def traceAsync[T, S](operationName: String)(body: T => S)(implicit settings: Settings): T => S = { t: T =>
     val span = startedSpan(operationName, settings)
     Kamon.store(Kamon.currentContext().withKey(Span.Key, span))
 

--- a/kamon-scala-future/src/test/scala/kamon/instrumentation/futures/scala/FutureInstrumentationSpec.scala
+++ b/kamon-scala-future/src/test/scala/kamon/instrumentation/futures/scala/FutureInstrumentationSpec.scala
@@ -121,7 +121,7 @@ class FutureInstrumentationSpec extends WordSpec with ScalaFutures with Matchers
           Future(Kamon.currentContext().getTag(plain("key")))
         }
 
-        whenReady(contextTag)(tagValue ⇒ tagValue shouldBe "value")
+        whenReady(contextTag)(tagValue => tagValue shouldBe "value")
         ensureExecutionContextIsClean()
       }
 
@@ -131,11 +131,11 @@ class FutureInstrumentationSpec extends WordSpec with ScalaFutures with Matchers
             Future("Hello Kamon!")
               // The current context is expected to be available during all intermediate processing.
               .map(_.length)
-              .flatMap(len ⇒ Future(len.toString))
-              .map(_ ⇒ Kamon.currentContext().getTag(plain("key")))
+              .flatMap(len => Future(len.toString))
+              .map(_ => Kamon.currentContext().getTag(plain("key")))
           }
 
-        whenReady(tagAfterTransformation)(tagValue ⇒ tagValue shouldBe "value")
+        whenReady(tagAfterTransformation)(tagValue => tagValue shouldBe "value")
         ensureExecutionContextIsClean()
       }
     }

--- a/kamon-scala-future/src/test/scala/kamon/instrumentation/futures/scala/FutureInstrumentationSpec.scala
+++ b/kamon-scala-future/src/test/scala/kamon/instrumentation/futures/scala/FutureInstrumentationSpec.scala
@@ -32,18 +32,18 @@ import scala.concurrent.{ExecutionContext, Future}
 class FutureInstrumentationSpec extends WordSpec with ScalaFutures with Matchers with PatienceConfiguration
     with OptionValues with Eventually with TestSpanReporter {
 
-  import kamon.instrumentation.futures.scala.ScalaFutureInstrumentation.{traced, tracedCallback}
+  import kamon.instrumentation.futures.scala.ScalaFutureInstrumentation.{trace, traceAsync}
   implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(1))
 
   "a Scala Future" when {
     "manually instrumented" should {
       "create Delayed Spans for a traced future and traced callbacks" in {
-        Future(traced("future-body")("this is the future body"))
-          .map(tracedCallback("first-callback")(_.length))
+        Future(trace("future-body")("this is the future body"))
+          .map(traceAsync("first-callback")(_.length))
           .map(_ * 10)
-          .flatMap(tracedCallback("second-callback")(Future(_)))
+          .flatMap(traceAsync("second-callback")(Future(_)))
           .map(_ * 10)
-          .filter(tracedCallback("third-callback")(_.toString.length > 10))
+          .filter(traceAsync("third-callback")(_.toString.length > 10))
 
         val spans = testSpanReporter.spans(200 millis)
         val bodySpan = spans.find(_.operationName == "future-body").get
@@ -64,13 +64,13 @@ class FutureInstrumentationSpec extends WordSpec with ScalaFutures with Matchers
       }
 
       "propagate the last chained Context when failures happen" in {
-        Future(traced("future-body")("this is the future body"))
-          .map(tracedCallback("first-callback")(_.length))
+        Future(trace("future-body")("this is the future body"))
+          .map(traceAsync("first-callback")(_.length))
           .map(_ / 0)
-          .flatMap(tracedCallback("second-callback")(Future(_))) // this will never happen
+          .flatMap(traceAsync("second-callback")(Future(_))) // this will never happen
           .map(_ * 10)
           .recover { case _ => "recovered" }
-          .map(tracedCallback("third-callback")(_.toString))
+          .map(traceAsync("third-callback")(_.toString))
 
         val spans = testSpanReporter.spans(200 millis)
         val bodySpan = spans.find(_.operationName == "future-body").get
@@ -87,10 +87,10 @@ class FutureInstrumentationSpec extends WordSpec with ScalaFutures with Matchers
 
       "be usable when working with for comprehensions" in {
         for {
-          first <- Future(traced("first-future")("this is the future body"))
-          second <- Future(traced("second-future")(first.length))
-          third <- Future(traced("third-future")(second * 10))
-        } yield traced("yield") {
+          first <- Future(trace("first-future")("this is the future body"))
+          second <- Future(trace("second-future")(first.length))
+          third <- Future(trace("third-future")(second * 10))
+        } yield trace("yield") {
           Kamon.currentSpan().tag("location", "atTheYield")
           "Hello World! " * third
         }

--- a/kamon-scalaz-future/src/test/scala/kamon/instrumentation/futures/scalaz/FutureInstrumentationSpec.scala
+++ b/kamon-scalaz-future/src/test/scala/kamon/instrumentation/futures/scalaz/FutureInstrumentationSpec.scala
@@ -52,8 +52,8 @@ class FutureInstrumentationSpec extends WordSpec with Matchers with ScalaFutures
           Future("Hello Kamon!")
             // The current context is expected to be available during all intermediate processing.
             .map(_.length)
-            .flatMap(len ⇒ Future(len.toString))
-            .map(_ ⇒ Kamon.currentContext().getTag(plain("key")))
+            .flatMap(len => Future(len.toString))
+            .map(_ => Kamon.currentContext().getTag(plain("key")))
             .unsafeStart
         }
 

--- a/kamon-twitter-future/src/test/scala/kamon/instrumentation/futures/twitter/FutureInstrumentationSpec.scala
+++ b/kamon-twitter-future/src/test/scala/kamon/instrumentation/futures/twitter/FutureInstrumentationSpec.scala
@@ -52,8 +52,8 @@ class FutureInstrumentationSpec extends WordSpec with Matchers with ScalaFutures
           FuturePool.unboundedPool("Hello Kamon!")
             // The current context is expected to be available during all intermediate processing.
             .map(_.length)
-            .flatMap(len ⇒ FuturePool.unboundedPool(len.toString))
-            .map(_ ⇒ Kamon.currentContext().getTag(plain("key")))
+            .flatMap(len => FuturePool.unboundedPool(len.toString))
+            .map(_ => Kamon.currentContext().getTag(plain("key")))
         }
 
         Await.result(tagAfterTransformations) shouldBe "value"


### PR DESCRIPTION
This makes the project compile and instrument Scala 2.13 Futures! Also, since we recently got support for Scala 2.13 on kamon-executors, this update is also ensuring that tests are working on Scala 2.13 for scalaz-concurrent (util-core and cats-effect were not available for 2.13).

I tested locally with a build of what will become Kanela 1.0.0-RC4, but that dependency has not been published yet so this will break until we get it out, which should happen later today.