### PR TITLE
upgrade to the latest 2.0 modules and rework tracing helpers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,11 +13,11 @@
  * =========================================================================================
  */
 
-val kamonCore        = "io.kamon"     %% "kamon-core"                   % "2.0.0-RC1"
-val kamonTestkit     = "io.kamon"     %% "kamon-testkit"                % "2.0.0-RC1"
-val kamonExecutors   = "io.kamon"     %% "kamon-executors"              % "2.0.0-RC2"
-val kamonInstrument  = "io.kamon"     %% "kamon-instrumentation-common" % "2.0.0-RC1"
-val kanelaAgent      = "io.kamon"     %  "kanela-agent"                 % "1.0.0-RC4"
+val kamonCore        = "io.kamon"     %% "kamon-core"                   % "2.0.0"
+val kamonTestkit     = "io.kamon"     %% "kamon-testkit"                % "2.0.0"
+val kamonExecutors   = "io.kamon"     %% "kamon-executors"              % "2.0.0"
+val kamonInstrument  = "io.kamon"     %% "kamon-instrumentation-common" % "2.0.0"
+val kanelaAgent      = "io.kamon"     %  "kanela-agent"                 % "1.0.0"
 
 val twitterUtilCore  = "com.twitter"   %% "util-core"                   % "6.40.0"
 val scalazConcurrent = "org.scalaz"    %% "scalaz-concurrent"           % "7.2.28"
@@ -25,7 +25,7 @@ val catsEffect       = "org.typelevel" %%  "cats-effect"                % "1.2.0
 
 resolvers in ThisBuild += Resolver.bintrayRepo("kamon-io", "snapshots")
 resolvers in ThisBuild += Resolver.mavenLocal
-scalaVersion := "2.13.0"
+scalaVersion := "2.12.8"
 
 lazy val `kamon-futures` = (project in file("."))
   .enablePlugins(JavaAgent)
@@ -38,25 +38,25 @@ lazy val `kamon-futures` = (project in file("."))
 
 lazy val `kamon-twitter-future` = (project in file("kamon-twitter-future"))
   .enablePlugins(JavaAgent)
-  .settings(noPublishing: _*)
   .settings(instrumentationSettings)
   .settings(
+    scalaVersion := "2.12.8",
     bintrayPackage := "kamon-futures",
+    crossScalaVersions := Seq("2.11.12", "2.12.8"),
     libraryDependencies ++=
-      compileScope(kamonCore) ++
-      providedScope(twitterUtilCore, kamonExecutors) ++
+      compileScope(kamonCore, kamonExecutors) ++
+      providedScope(kanelaAgent, twitterUtilCore) ++
       testScope(scalatest, kamonTestkit, logbackClassic))
 
 lazy val `kamon-scalaz-future` = (project in file("kamon-scalaz-future"))
   .enablePlugins(JavaAgent)
-  .settings(noPublishing: _*)
   .settings(instrumentationSettings)
   .settings(
     bintrayPackage := "kamon-futures",
     crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
     libraryDependencies ++=
-      compileScope(kamonCore) ++
-      providedScope(scalazConcurrent, kamonExecutors) ++
+      compileScope(kamonCore, kamonExecutors) ++
+      providedScope(kanelaAgent, scalazConcurrent) ++
       testScope(scalatest, kamonTestkit, logbackClassic))
 
 lazy val `kamon-scala-future` = (project in file("kamon-scala-future"))
@@ -72,11 +72,12 @@ lazy val `kamon-scala-future` = (project in file("kamon-scala-future"))
 
 lazy val `kamon-cats-io` = (project in file("kamon-cats-io"))
   .enablePlugins(JavaAgent)
-  .settings(noPublishing: _*)
   .settings(bintrayPackage := "kamon-futures")
   .settings(instrumentationSettings)
   .settings(
+    scalaVersion := "2.12.8",
+    crossScalaVersions := Seq("2.11.12", "2.12.8"),
     libraryDependencies ++=
-      compileScope(kamonCore, kamonInstrument) ++
-      providedScope(catsEffect, kanelaAgent, kamonExecutors) ++
+      compileScope(kamonCore, kamonExecutors) ++
+      providedScope(catsEffect, kanelaAgent) ++
       testScope(scalatest, kamonTestkit, logbackClassic))

--- a/kamon-cats-io/src/main/resources/reference.conf
+++ b/kamon-cats-io/src/main/resources/reference.conf
@@ -1,0 +1,9 @@
+#############################################
+#   Kamon Cats IO Reference Configuration   #
+#############################################
+
+kanela.modules {
+  executor-service {
+    within += "cats.effect.internals.IOShift\\$Tick"
+  }
+}

--- a/kamon-cats-io/src/test/scala/kamon/instrumentation/futures/cats/CatsIOInstrumentationSpec.scala
+++ b/kamon-cats-io/src/test/scala/kamon/instrumentation/futures/cats/CatsIOInstrumentationSpec.scala
@@ -30,7 +30,7 @@ class CatsIoInstrumentationSpec extends WordSpec with ScalaFutures with Matchers
         val contextTagAfterTransformations =
           for {
             scope <- IO {
-              Kamon.store(context)
+              Kamon.storeContext(context)
             }
             len <- IO("Hello Kamon!").map(_.length)
             _ <- IO(len.toString)

--- a/kamon-scala-future/src/main/scala-2.11/kamon/instrumentation/futures/scala/FutureChainingInstrumentation.scala
+++ b/kamon-scala-future/src/main/scala-2.11/kamon/instrumentation/futures/scala/FutureChainingInstrumentation.scala
@@ -74,7 +74,7 @@ object CallbackRunnableRunInstrumentation {
     val context = if(valueContext.nonEmpty()) valueContext else runnable.context
 
     storeCurrentRunnableTimestamp(timestamp)
-    Kamon.store(context)
+    Kamon.storeContext(context)
   }
 
   @Advice.OnMethodExit(suppress = classOf[Throwable])
@@ -105,7 +105,7 @@ object PromiseCompletingRunnableRunInstrumentation {
   @Advice.OnMethodEnter(suppress = classOf[Throwable])
   def enter(@Advice.This runnable: HasContext with HasTimestamp): Scope = {
     CallbackRunnableRunInstrumentation.storeCurrentRunnableTimestamp(runnable.timestamp)
-    Kamon.store(runnable.context)
+    Kamon.storeContext(runnable.context)
   }
 
   @Advice.OnMethodExit(suppress = classOf[Throwable])

--- a/kamon-scala-future/src/main/scala-2.12/kamon/instrumentation/futures/scala/FutureChainingInstrumentation.scala
+++ b/kamon-scala-future/src/main/scala-2.12/kamon/instrumentation/futures/scala/FutureChainingInstrumentation.scala
@@ -75,7 +75,7 @@ object CallbackRunnableRunInstrumentation {
     val context = if(valueContext.nonEmpty()) valueContext else runnable.context
 
     storeCurrentRunnableTimestamp(timestamp)
-    Kamon.store(context)
+    Kamon.storeContext(context)
   }
 
   @Advice.OnMethodExit(suppress = classOf[Throwable])

--- a/kamon-scala-future/src/main/scala-2.13/kamon/instrumentation/futures/scala/FutureChainingInstrumentation.scala
+++ b/kamon-scala-future/src/main/scala-2.13/kamon/instrumentation/futures/scala/FutureChainingInstrumentation.scala
@@ -77,7 +77,7 @@ object CallbackRunnableRunInstrumentation {
     val context = if(valueContext.nonEmpty()) valueContext else runnable.context
 
     storeCurrentRunnableTimestamp(timestamp)
-    Kamon.store(context)
+    Kamon.storeContext(context)
   }
 
   @Advice.OnMethodExit(suppress = classOf[Throwable])

--- a/kamon-scala-future/src/main/scala/kamon/instrumentation/futures/scala/ScalaFutureInstrumentation.scala
+++ b/kamon-scala-future/src/main/scala/kamon/instrumentation/futures/scala/ScalaFutureInstrumentation.scala
@@ -18,8 +18,12 @@ package kamon.instrumentation.futures.scala
 
 import com.typesafe.config.Config
 import kamon.Kamon
+import kamon.tag.TagSet
 import kamon.trace.{Span, SpanBuilder}
+import kamon.util.CallingThreadExecutionContext
 
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
 
@@ -28,26 +32,98 @@ object ScalaFutureInstrumentation {
   val Component = "scala.future"
 
   /**
-    * Traces the execution of a block of code with a Delayed Span which takes into account the scheduling time when run
+    * Traces the execution of an asynchronous computation modeled by a Future. This function will create a Span when it
+    * starts executing and set that Span as current while the code that created the actual Future executes and then,
+    * automatically finish that Span when the created Future finishes execution.
+    *
+    * The purpose of this function is to make it easy to trace an asynchronous computation as a whole, even though such
+    * computation might be the result of applying several transformations to an initial Future. If you are interested in
+    * tracing the intermediate computations as well, take a look at the `traceBody` and `traceFunc` functions bellow.
+    */
+  def trace[T](operationName: String, tags: TagSet = TagSet.Empty, metricTags: TagSet = TagSet.Empty)(future: => Future[T])
+      (implicit settings: Settings): Future[T] = {
+
+    val spanBuilder = Kamon.internalSpanBuilder(operationName, Component)
+    if(tags.nonEmpty()) spanBuilder.tag(tags)
+    if(metricTags.nonEmpty()) spanBuilder.tagMetrics(metricTags)
+
+    trace(spanBuilder)(future)(settings)
+  }
+
+  /**
+    * Traces the execution of an asynchronous computation modeled by a Future. This function will create a Span when it
+    * starts executing and set that Span as current while the code that created the actual Future executes and then,
+    * automatically finish that Span when the created Future finishes execution.
+    *
+    * The purpose of this function is to make it easy to trace an asynchronous computation as a whole, even though such
+    * computation might be the result of applying several transformations to an initial Future. If you are interested in
+    * tracing the intermediate computations as well, take a look at the `traceBody` and `traceFunc` functions bellow.
+    */
+  def trace[T](spanBuilder: SpanBuilder)(future: => Future[T])(implicit settings: Settings): Future[T] = {
+    if(settings.trackMetrics)
+      spanBuilder.trackMetrics()
+    else
+      spanBuilder.doNotTrackMetrics()
+
+    val futureSpan = spanBuilder.start()
+    val evaluatedFuture = Kamon.runWithSpan(futureSpan, finishSpan = false)(future)
+    evaluatedFuture.onComplete {
+      case Success(_)       => futureSpan.finish()
+      case Failure(failure) => futureSpan.fail(failure).finish()
+    } (CallingThreadExecutionContext)
+
+    evaluatedFuture
+  }
+
+  /**
+    * Traces the execution of Future's body with a Delayed Span which takes into account the scheduling time when run
     * inside of a CallbackRunnable. This function is expected to be used when creating new Futures and wrapping the
     * entire body of the Future as follows:
     *
-    *   Future(traced("myAsyncOperationName") {
+    *   Future(traceBody("myAsyncOperationName") {
     *     // Here goes the future body.
     *   })
     *
     * If the scheduling time cannot be determined this function will fall back to using a regular Span for tracking the
-    * traced operation since the only reasonable value for the scheduling time would be the start time, which would
+    * Future's body since the only reasonable value for the scheduling time would be the start time, which would
     * yield no wait time and the same processing and elapsed time, rendering the Delayed Span useless.
     *
     * IMPORTANT: Do not use this method if you are not going to run your application with instrumentation enabled. This
-    *            method contains a call to Kamon.store(...) which will only be cleaned up by the CallbackRunnable
+    *            method contains a call to Kamon.storeContext(...) which will only be cleaned up by the CallbackRunnable
     *            bytecode instrumentation. If instrumentation is disabled you risk leaving dirty threads that can cause
     *            incorrect Context propagation behavior.
     */
-  def trace[S](operationName: String)(body: => S)(implicit settings: Settings): S = {
-    val span = startedSpan(operationName, settings)
-    Kamon.store(Kamon.currentContext().withKey(Span.Key, span))
+  def traceBody[S](operationName: String, tags: TagSet = TagSet.Empty, metricTags: TagSet = TagSet.Empty)(body: => S)
+      (implicit settings: Settings): S = {
+
+    val spanBuilder = Kamon.internalSpanBuilder(operationName, Component)
+    if(tags.nonEmpty()) spanBuilder.tag(tags)
+    if(metricTags.nonEmpty()) spanBuilder.tagMetrics(metricTags)
+
+    traceBody(spanBuilder)(body)(settings)
+  }
+
+  /**
+    * Traces the execution of Future's body with a Delayed Span which takes into account the scheduling time when run
+    * inside of a CallbackRunnable. This function is expected to be used when creating new Futures and wrapping the
+    * entire body of the Future as follows:
+    *
+    *   Future(traceBody("myAsyncOperationName") {
+    *     // Here goes the future body.
+    *   })
+    *
+    * If the scheduling time cannot be determined this function will fall back to using a regular Span for tracking the
+    * Future's body since the only reasonable value for the scheduling time would be the start time, which would
+    * yield no wait time and the same processing and elapsed time, rendering the Delayed Span useless.
+    *
+    * IMPORTANT: Do not use this method if you are not going to run your application with instrumentation enabled. This
+    *            method contains a call to Kamon.storeContext(...) which will only be cleaned up by the CallbackRunnable
+    *            bytecode instrumentation. If instrumentation is disabled you risk leaving dirty threads that can cause
+    *            incorrect Context propagation behavior.
+    */
+  def traceBody[S](spanBuilder: SpanBuilder)(body: => S)(implicit settings: Settings): S = {
+    val span = startedSpan(spanBuilder, settings)
+    Kamon.storeContext(Kamon.currentContext().withEntry(Span.Key, span))
 
     try {
       body
@@ -61,26 +137,54 @@ object ScalaFutureInstrumentation {
   }
 
   /**
-    * Traces the execution of a callback on a Future with a Delayed Span which takes into account the scheduling time
+    * Traces the execution of a transformation on a Future with a Delayed Span which takes into account the scheduling time
     * when run inside of a CallbackRunnable. This function is expected to be used when creating callbacks on Futures and
     * should wrap the entire actual callback as follows:
     *
     *   Future(...)
-    *     .map(tracedCallback("myMapCallbackName")( // Here goes the actual callback. ))
-    *     .filter(tracedCallback("myFilterCallbackName")( // Here goes the actual callback. ))
+    *     .map(traceFunc("myMapCallbackName")( // Here goes the actual callback. ))
+    *     .filter(traceFunc("myFilterCallbackName")( // Here goes the actual callback. ))
     *
     * If the scheduling time cannot be determined this function will fall back to using a regular Span for tracking the
     * traced callback since the only reasonable value for the scheduling time would be the start time, which would yield
     * no wait time and the same processing and elapsed time, rendering the Delayed Span useless.
     *
     * IMPORTANT: Do not use this method if you are not going to run your application with instrumentation enabled. This
-    *            method contains a call to Kamon.store(...) which will only be cleaned up by the CallbackRunnable
+    *            method contains a call to Kamon.storeContext(...) which will only be cleaned up by the CallbackRunnable
     *            bytecode instrumentation. If instrumentation is disabled you risk leaving dirty threads that can cause
     *            incorrect Context propagation behavior.
     */
-  def traceAsync[T, S](operationName: String)(body: T => S)(implicit settings: Settings): T => S = { t: T =>
-    val span = startedSpan(operationName, settings)
-    Kamon.store(Kamon.currentContext().withKey(Span.Key, span))
+  def traceFunc[T, S](operationName: String, tags: TagSet = TagSet.Empty, metricTags: TagSet = TagSet.Empty)(body: T => S)
+      (implicit settings: Settings): T => S = {
+
+    val spanBuilder = Kamon.internalSpanBuilder(operationName, Component)
+    if(tags.nonEmpty()) spanBuilder.tag(tags)
+    if(metricTags.nonEmpty()) spanBuilder.tagMetrics(metricTags)
+
+    traceFunc(spanBuilder)(body)(settings)
+  }
+
+  /**
+    * Traces the execution of a transformation on a Future with a Delayed Span which takes into account the scheduling time
+    * when run inside of a CallbackRunnable. This function is expected to be used when creating callbacks on Futures and
+    * should wrap the entire actual callback as follows:
+    *
+    *   Future(...)
+    *     .map(traceFunc("myMapCallbackName")( // Here goes the actual callback. ))
+    *     .filter(traceFunc("myFilterCallbackName")( // Here goes the actual callback. ))
+    *
+    * If the scheduling time cannot be determined this function will fall back to using a regular Span for tracking the
+    * traced callback since the only reasonable value for the scheduling time would be the start time, which would yield
+    * no wait time and the same processing and elapsed time, rendering the Delayed Span useless.
+    *
+    * IMPORTANT: Do not use this method if you are not going to run your application with instrumentation enabled. This
+    *            method contains a call to Kamon.storeContext(...) which will only be cleaned up by the CallbackRunnable
+    *            bytecode instrumentation. If instrumentation is disabled you risk leaving dirty threads that can cause
+    *            incorrect Context propagation behavior.
+    */
+  def traceFunc[T, S](spanBuilder: SpanBuilder)(body: T => S)(implicit settings: Settings): T => S = { t: T =>
+    val span = startedSpan(spanBuilder, settings)
+    Kamon.storeContext(Kamon.currentContext().withEntry(Span.Key, span))
 
     try {
       body(t)
@@ -95,12 +199,9 @@ object ScalaFutureInstrumentation {
 
 
   /**
-    * Settings for the Delayed Spans created by the traced and tracedCallback helper functions.
+    * Settings for the Delayed Spans created by the traceBody and traceFunc helper functions.
     */
-  case class Settings(trackMetrics: Boolean, trackDelayedSpanMetrics: Boolean, builderTransformation: SpanBuilder => SpanBuilder) {
-    def transform(t: SpanBuilder => SpanBuilder): Settings =
-      copy(builderTransformation = t)
-  }
+  case class Settings(trackMetrics: Boolean, trackDelayedSpanMetrics: Boolean)
 
   object Settings {
 
@@ -116,13 +217,13 @@ object ScalaFutureInstrumentation {
     /**
       * Completely disables tracking metrics on traced blocks and callbacks.
       */
-    val NoMetrics = Settings(false, false, identity)
+    val NoMetrics = Settings(false, false)
 
     /**
       * Disables tracking of Delayed Span metrics (i.e. the "span.wait-time" and "span.elapsed-time" metrics will not be
       * tracked).
       */
-    val NoDelayedSpanMetrics = Settings(true, false, identity)
+    val NoDelayedSpanMetrics = Settings(true, false)
 
 
     private def readSettingsFromConfig(config: Config): Settings = {
@@ -130,8 +231,7 @@ object ScalaFutureInstrumentation {
 
       Settings(
         trackMetrics = futureInstrumentationConfig.getBoolean("trace.track-span-metrics"),
-        trackDelayedSpanMetrics = futureInstrumentationConfig.getBoolean("trace.track-span-metrics"),
-        builderTransformation = identity
+        trackDelayedSpanMetrics = futureInstrumentationConfig.getBoolean("trace.track-span-metrics")
       )
     }
   }
@@ -140,19 +240,18 @@ object ScalaFutureInstrumentation {
     * Starts a regular Span or a Delayed Span, depending on whether the scheduling time of the CallbackRunnable where
     * we are executing at the moment (if any) can be determined.
     */
-  private def startedSpan(operationName: String, settings: Settings): Span = {
+  private def startedSpan(spanBuilder: SpanBuilder, settings: Settings): Span = {
     CallbackRunnableRunInstrumentation.currentRunnableScheduleTimestamp() match {
       case Some(timestamp) =>
         val scheduledAt = Kamon.clock().toInstant(timestamp)
-        val span = settings.builderTransformation(Kamon.internalSpanBuilder(operationName, Component)).delay(scheduledAt)
+        val span = spanBuilder.delay(scheduledAt)
         if(!settings.trackMetrics) span.doNotTrackMetrics()
         if(!settings.trackDelayedSpanMetrics) span.doNotTrackDelayedSpanMetrics()
         span.start()
 
       case None =>
-        val span = settings.builderTransformation(Kamon.internalSpanBuilder(operationName, Component))
-        if(!settings.trackMetrics) span.doNotTrackMetrics()
-        span.start()
+        if(!settings.trackMetrics) spanBuilder.doNotTrackMetrics()
+        spanBuilder.start()
     }
   }
 }

--- a/kamon-scalaz-future/src/main/resources/reference.conf
+++ b/kamon-scalaz-future/src/main/resources/reference.conf
@@ -1,0 +1,9 @@
+###################################################
+#   Kamon Scalaz Future Reference Configuration   #
+###################################################
+
+kanela.modules {
+  executor-service {
+    within += "scalaz.concurrent.*"
+  }
+}

--- a/kamon-scalaz-future/src/test/scala/kamon/instrumentation/futures/scalaz/FutureInstrumentationSpec.scala
+++ b/kamon-scalaz-future/src/test/scala/kamon/instrumentation/futures/scalaz/FutureInstrumentationSpec.scala
@@ -39,7 +39,7 @@ class FutureInstrumentationSpec extends WordSpec with Matchers with ScalaFutures
       "must be available when executing the future's body" in {
 
         val context = Context.of("key", "value")
-        val tagInBody = Kamon.storeContext(context) {
+        val tagInBody = Kamon.runWithContext(context) {
           Future(Kamon.currentContext().getTag(plain("key"))).unsafeStart
         }
 
@@ -48,7 +48,7 @@ class FutureInstrumentationSpec extends WordSpec with Matchers with ScalaFutures
 
       "must be available when executing callbacks on the future" in {
         val context = Context.of("key", "value")
-        val baggageAfterTransformations = Kamon.storeContext(context) {
+        val baggageAfterTransformations = Kamon.runWithContext(context) {
           Future("Hello Kamon!")
             // The current context is expected to be available during all intermediate processing.
             .map(_.length)

--- a/kamon-twitter-future/src/main/resources/reference.conf
+++ b/kamon-twitter-future/src/main/resources/reference.conf
@@ -1,0 +1,10 @@
+####################################################
+#   Kamon Twitter Future Reference Configuration   #
+####################################################
+
+kanela.modules {
+  executor-service {
+    within += "com.twitter.util.*"
+    exclude += "com.twitter.util.ConstFuture.*"
+  }
+}

--- a/kamon-twitter-future/src/test/scala/kamon/instrumentation/futures/twitter/FutureInstrumentationSpec.scala
+++ b/kamon-twitter-future/src/test/scala/kamon/instrumentation/futures/twitter/FutureInstrumentationSpec.scala
@@ -38,7 +38,7 @@ class FutureInstrumentationSpec extends WordSpec with Matchers with ScalaFutures
       "must be available when executing the future's body" in {
 
         val context = Context.of("key", "value")
-        val tagInBody = Kamon.storeContext(context) {
+        val tagInBody = Kamon.runWithContext(context) {
           FuturePool(execContext)(Kamon.currentContext().getTag(plain("key")))
         }
 
@@ -48,7 +48,7 @@ class FutureInstrumentationSpec extends WordSpec with Matchers with ScalaFutures
       "must be available when executing callbacks on the future" in {
 
         val context = Context.of("key", "value")
-        val tagAfterTransformations = Kamon.storeContext(context) {
+        val tagAfterTransformations = Kamon.runWithContext(context) {
           FuturePool.unboundedPool("Hello Kamon!")
             // The current context is expected to be available during all intermediate processing.
             .map(_.length)


### PR DESCRIPTION
This PR upgrades the module to the latest changes in kamon-executors introduced in https://github.com/kamon-io/kamon-executors/commit/d9392de4bf6aa0291cb135f4fb80eb14dec50a64 which basically means that we will need to be explicit about what Runnable/Callable implementations we are targeting and that made it necessary to bring back the Twitter/Scalaz/CatsIO modules although they only contain a bit of configuration and that's it. 

Beyond that, the real big improvement here (hopefully) is the conclusion of all discussions happening at https://github.com/kamon-io/kamon-futures/pull/5 and https://github.com/kamon-io/kamon-futures/issues/3, which is all in [this file](https://github.com/kamon-io/kamon-futures/compare/master...ivantopo:upgrade-to-latest-2.0?expand=1#diff-769361eefe75c86cbba4210ecd046f11). Long story short is:
  - We have three separate tracing functions: trace, traceBody and traceFun which are targeted to tracing any Future, a Future's body and a Future's transformation, respectively.
  - Each function has two variants: one accepting the operationName and possible tags and metric tags and the other accepting a SpanBuilder.

This should be enough to cover all the basic use cases and if more arrive in the Future we can review and expand these helpers.

I'm starting this as a draft because I'm already building this branch with a local version that contains https://github.com/kamon-io/Kamon/pull/594 and https://github.com/kamon-io/Kamon/pull/595, but that shouldn't stop from getting some feedback.

/cc @jatcwang @jtjeferreira @jalaziz @dpsoft 